### PR TITLE
Some changes were made:

### DIFF
--- a/docs/check-update.html
+++ b/docs/check-update.html
@@ -3,7 +3,7 @@
 <head>
     <script>
         var CURRENT_VERSION = 121;
-        var RELEASE_URL = "https://github.com/devlinx9/muon-ssh/releases/tag/v1.2.1";
+        var RELEASE_URL = "https://github.com/devlinx9/muon-ssh/releases/tag/v2.0.0";
         function printVersion() {
             var rx = /\?v=(\d+)/;
             var str = window.location.search;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: muon
-version: "1.2.1"
+version: "2.0.0"
 summary: Graphical SFTP client and terminal emulator with helpful utilities
 description: |
   Muon is a graphical SSH client. It has a file browser,
@@ -15,7 +15,7 @@ confinement: strict
 
 apps:
   muon:
-    command: java -jar $SNAP/jar/muon_1.2.1.jar
+    command: java -jar $SNAP/jar/muonssh_2.0.0.jar
     environment:
       # Needed for fontconfig
       XDG_DATA_HOME: ${SNAP}/usr/share


### PR DESCRIPTION
- Support for importing SSH config files was added
- The problem with snowflake ticket 186 was solved
- In settings, two additional fields were added for sudo validation
- Main screen can be selected between SSH and FileBrowser
- The name of muon was changed to muonssh because in Ubuntu there is already a package with the name of muon