### PR TITLE
Remove Dead Repository

### DIFF
--- a/muon-app/pom.xml
+++ b/muon-app/pom.xml
@@ -371,10 +371,5 @@
             <name>jcenter</name>
             <url>https://jcenter.bintray.com</url>
         </repository>
-        <repository>
-            <id>personal</id>
-            <name>extra</name>
-            <url>https://subhra74.github.io/extra-jars/</url>
-        </repository>
     </repositories>
 </project>


### PR DESCRIPTION
I removed the repository: https://subhra74.github.io/extra-jars as it is from the previous maintainer and seems to be offline. As there are no packages loaded from there, it is not needed.