### PR TITLE
enhance site and folder management UI with editable states

### DIFF
--- a/muon-app/src/main/java/muon/app/ui/components/session/JumpHostPanel.java
+++ b/muon-app/src/main/java/muon/app/ui/components/session/JumpHostPanel.java
@@ -19,7 +19,13 @@ import static muon.app.util.Constants.MEDIUM_TEXT_SIZE;
 public class JumpHostPanel extends JPanel {
     private final DefaultListModel<HopEntry> hopModel = new DefaultListModel<>();
     private final JList<HopEntry> hopList = new JList<>(hopModel);
+    private final JButton btnAdd;
+    private final JButton btnDel;
+    private final JButton btnEdit;
+    private final JButton btnUp;
+    private final JButton btnDown;
     private SessionInfo info;
+    private boolean editable = true;
 
     public JumpHostPanel() {
         super(new BorderLayout(5, 5));
@@ -29,18 +35,19 @@ public class JumpHostPanel extends JPanel {
         JScrollPane scrollPane = new SkinnedScrollPane(hopList);
 
         Box b1 = Box.createVerticalBox();
-        JButton btnAdd = new JButton(FontAwesomeContants.FA_PLUS);
+        btnAdd = new JButton(FontAwesomeContants.FA_PLUS);
         btnAdd.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnDel = new JButton(FontAwesomeContants.FA_MINUS);
+        btnDel = new JButton(FontAwesomeContants.FA_MINUS);
         btnDel.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnEdit = new JButton(FontAwesomeContants.FA_PENCIL);
+        btnEdit = new JButton(FontAwesomeContants.FA_PENCIL);
         btnEdit.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnUp = new JButton(FontAwesomeContants.FA_ARROW_UP);
+        btnUp = new JButton(FontAwesomeContants.FA_ARROW_UP);
         btnUp.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnDown = new JButton(FontAwesomeContants.FA_ARROW_DOWN);
+        btnDown = new JButton(FontAwesomeContants.FA_ARROW_DOWN);
         btnDown.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
 
         btnAdd.addActionListener(e -> {
+            if (!editable) return;
             HopEntry ent = addOrEditEntry(null);
             if (ent != null) {
                 hopModel.addElement(ent);
@@ -49,6 +56,7 @@ public class JumpHostPanel extends JPanel {
         });
 
         btnEdit.addActionListener(e -> {
+            if (!editable) return;
             int index = hopList.getSelectedIndex();
             if (index != -1) {
                 HopEntry ent = hopModel.get(index);
@@ -62,6 +70,7 @@ public class JumpHostPanel extends JPanel {
         });
 
         btnDel.addActionListener(e -> {
+            if (!editable) return;
             int index = hopList.getSelectedIndex();
             if (index != -1) {
                 hopModel.remove(index);
@@ -70,6 +79,7 @@ public class JumpHostPanel extends JPanel {
         });
 
         btnUp.addActionListener(e -> {
+            if (!editable) return;
             int index = hopList.getSelectedIndex();
             if (index > 0) {
                 HopEntry ent = hopModel.remove(index);
@@ -79,6 +89,7 @@ public class JumpHostPanel extends JPanel {
         });
 
         btnDown.addActionListener(e -> {
+            if (!editable) return;
             int index = hopList.getSelectedIndex();
             if (index < hopModel.size() - 1) {
                 HopEntry ent = hopModel.remove(index);
@@ -105,6 +116,16 @@ public class JumpHostPanel extends JPanel {
         this.add(lblTitle, BorderLayout.NORTH);
         this.add(scrollPane);
         this.add(b1, BorderLayout.EAST);
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+        hopList.setEnabled(editable);
+        btnAdd.setEnabled(editable);
+        btnEdit.setEnabled(editable);
+        btnDel.setEnabled(editable);
+        btnUp.setEnabled(editable);
+        btnDown.setEnabled(editable);
     }
 
     private List<HopEntry> getJumpHosts() {

--- a/muon-app/src/main/java/muon/app/ui/components/session/PortForwardingPanel.java
+++ b/muon-app/src/main/java/muon/app/ui/components/session/PortForwardingPanel.java
@@ -21,7 +21,11 @@ import static muon.app.util.ScalingUtil.getScaledEmptyBorder;
 public class PortForwardingPanel extends JPanel {
     private final PFTableModel model;
     private final JTable table;
+    private final JButton btnAdd;
+    private final JButton btnDel;
+    private final JButton btnEdit;
     private SessionInfo info;
+    private boolean editable = true;
 
     public PortForwardingPanel() {
         super(new BorderLayout(10, 10));
@@ -35,14 +39,15 @@ public class PortForwardingPanel extends JPanel {
         scrollPane.setPreferredSize(scale(new Dimension(400, 200)));
 
         Box b1 = Box.createVerticalBox();
-        JButton btnAdd = new JButton(FontAwesomeContants.FA_PLUS);
+        btnAdd = new JButton(FontAwesomeContants.FA_PLUS);
         btnAdd.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnDel = new JButton(FontAwesomeContants.FA_MINUS);
+        btnDel = new JButton(FontAwesomeContants.FA_MINUS);
         btnDel.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
-        JButton btnEdit = new JButton(FontAwesomeContants.FA_PENCIL);
+        btnEdit = new JButton(FontAwesomeContants.FA_PENCIL);
         btnEdit.setFont(App.getCONTEXT().getSkin().getIconFont(MEDIUM_TEXT_SIZE));
 
         btnAdd.addActionListener(e -> {
+            if (!editable) return;
             PortForwardingRule ent = addOrEditEntry(null);
             if (ent != null) {
                 model.addRule(ent);
@@ -51,6 +56,7 @@ public class PortForwardingPanel extends JPanel {
         });
 
         btnEdit.addActionListener(e -> {
+            if (!editable) return;
             int index = table.getSelectedRow();
             if (index != -1) {
                 PortForwardingRule ent = model.get(index);
@@ -62,6 +68,7 @@ public class PortForwardingPanel extends JPanel {
         });
 
         btnDel.addActionListener(e -> {
+            if (!editable) return;
             int index = table.getSelectedRow();
             if (index != -1) {
                 model.remove(index);
@@ -81,6 +88,15 @@ public class PortForwardingPanel extends JPanel {
         this.add(lblTitle, BorderLayout.NORTH);
         this.add(scrollPane);
         this.add(b1, BorderLayout.EAST);
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+        table.setEnabled(editable);
+        table.setRowSelectionAllowed(editable);
+        btnAdd.setEnabled(editable);
+        btnEdit.setEnabled(editable);
+        btnDel.setEnabled(editable);
     }
 
     private void updatePFRules() {

--- a/muon-app/src/main/java/muon/app/ui/components/session/SessionInfoPanel.java
+++ b/muon-app/src/main/java/muon/app/ui/components/session/SessionInfoPanel.java
@@ -11,6 +11,7 @@ import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.io.File;
 import java.nio.file.Files;
@@ -24,6 +25,7 @@ public class SessionInfoPanel extends JPanel {
 
     public static final int DEFAULT_MAX_PORT = 65535;
     private static final long serialVersionUID = 6679029920589652547L;
+    private static final String ORIG_COMBO_RENDERER = "orig.combo.renderer";
     private JTextField inpHostName;
     private JTextField inpUserName;
     private JPasswordField inpPassword;
@@ -65,6 +67,147 @@ public class SessionInfoPanel extends JPanel {
         }
     }
 
+    public void setEditable(boolean editable) {
+        applyEditability(this, editable);
+        if (panJumpHost != null) {
+            panJumpHost.setEditable(editable);
+        }
+        if (panPF != null) {
+            panPF.setEditable(editable);
+        }
+        applyReadOnlyColors(editable);
+        if (editable && info != null) {
+            applySftpOnlyState(info.isSftpOnly());
+        }
+    }
+
+    private void applyEditability(Component component, boolean editable) {
+        if (component instanceof JLabel) {
+            component.setEnabled(true);
+            return;
+        }
+
+        if (component instanceof JTextComponent) {
+            JTextComponent textComponent = (JTextComponent) component;
+            textComponent.setEnabled(true);
+            textComponent.setEditable(editable);
+            textComponent.setFocusable(editable);
+            return;
+        }
+
+        if (component instanceof JComboBox || component instanceof JSpinner || component instanceof AbstractButton
+                || component instanceof JTable || component instanceof JList || component instanceof JTree) {
+            component.setEnabled(editable);
+        }
+
+        if (component instanceof Container) {
+            Container container = (Container) component;
+            for (Component child : container.getComponents()) {
+                applyEditability(child, editable);
+            }
+        }
+    }
+
+    private void applyReadOnlyColors(boolean editable) {
+        Color readOnlyBg = App.getCONTEXT().getSkin().getReadOnlyFieldBackground();
+        Color readOnlyFg = App.getCONTEXT().getSkin().getReadOnlyFieldForeground();
+
+        for (Component c : getAllComponents(this)) {
+            boolean formControl = c instanceof JTextComponent || c instanceof JComboBox || c instanceof JSpinner || c instanceof JCheckBox || c instanceof JButton;
+            if (!formControl) continue;
+
+            boolean readOnlyText = c instanceof JTextComponent && !((JTextComponent) c).isEditable();
+            boolean disabled = !c.isEnabled();
+            if (readOnlyText || disabled) {
+                c.setBackground(readOnlyBg);
+                c.setForeground(readOnlyFg);
+                if (c instanceof JComponent) {
+                    ((JComponent) c).setOpaque(true);
+                }
+                if (c instanceof JTextComponent) {
+                    ((JTextComponent) c).setDisabledTextColor(readOnlyFg);
+                    ((JTextComponent) c).setCaretColor(readOnlyFg);
+                }
+                if (c instanceof JSpinner) {
+                    JComponent editor = ((JSpinner) c).getEditor();
+                    if (editor instanceof JSpinner.DefaultEditor) {
+                        JTextField tf = ((JSpinner.DefaultEditor) editor).getTextField();
+                        tf.setBackground(readOnlyBg);
+                        tf.setForeground(readOnlyFg);
+                        tf.setDisabledTextColor(readOnlyFg);
+                    }
+                    for (Component sc : ((JSpinner) c).getComponents()) {
+                        if (sc instanceof JButton || sc instanceof JComponent) {
+                            sc.setBackground(readOnlyBg);
+                            sc.setForeground(readOnlyFg);
+                            if (sc instanceof JComponent) {
+                                ((JComponent) sc).setOpaque(true);
+                            }
+                        }
+                    }
+                }
+                if (c instanceof JComboBox) {
+                    JComboBox<?> combo = (JComboBox<?>) c;
+                    combo.setBackground(readOnlyBg);
+                    combo.setForeground(readOnlyFg);
+                    applyComboRenderer(combo, readOnlyBg, readOnlyFg, true);
+                    ComboBoxEditor editor = combo.getEditor();
+                    if (editor != null && editor.getEditorComponent() instanceof JComponent) {
+                        JComponent ec = (JComponent) editor.getEditorComponent();
+                        ec.setBackground(readOnlyBg);
+                        ec.setForeground(readOnlyFg);
+                        ec.setOpaque(true);
+                    }
+                }
+            } else {
+                c.setBackground(null);
+                c.setForeground(null);
+                if (c instanceof JTextComponent) {
+                    ((JTextComponent) c).setDisabledTextColor(UIManager.getColor("nimbusDisabledText"));
+                }
+                if (c instanceof JComboBox) {
+                    applyComboRenderer((JComboBox<?>) c, readOnlyBg, readOnlyFg, false);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyComboRenderer(JComboBox<?> combo, Color bg, Color fg, boolean readOnly) {
+        if (readOnly) {
+            if (combo.getClientProperty(ORIG_COMBO_RENDERER) == null) {
+                combo.putClientProperty(ORIG_COMBO_RENDERER, combo.getRenderer());
+            }
+            combo.setRenderer(new DefaultListCellRenderer() {
+                @Override
+                public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                              boolean isSelected, boolean cellHasFocus) {
+                    JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                    if (index == -1 || isSelected) {
+                        label.setBackground(bg);
+                        label.setForeground(fg);
+                    }
+                    return label;
+                }
+            });
+        } else {
+            Object original = combo.getClientProperty(ORIG_COMBO_RENDERER);
+            if (original instanceof ListCellRenderer) {
+                combo.setRenderer((ListCellRenderer<? super Object>) original);
+            }
+        }
+    }
+
+    private java.util.List<Component> getAllComponents(Container c) {
+        java.util.List<Component> list = new java.util.ArrayList<>();
+        for (Component comp : c.getComponents()) {
+            list.add(comp);
+            if (comp instanceof Container) {
+                list.addAll(getAllComponents((Container) comp));
+            }
+        }
+        return list;
+    }
 
     public boolean validateFields() {
         if (inpHostName.getText().isEmpty()) {

--- a/muon-app/src/main/java/muon/app/ui/components/session/dialog/NewSessionDlg.java
+++ b/muon-app/src/main/java/muon/app/ui/components/session/dialog/NewSessionDlg.java
@@ -35,6 +35,9 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
     private SessionInfoPanel sessionInfoPanel;
     private JButton btnConnect;
     private JButton btnCancel;
+    private JButton btnEdit;
+    private boolean editMode = false;
+    private boolean pendingEditOnSelect = false;
     private JTextField txtName;
     private NamedItem selectedInfo;
     private SessionInfo info;
@@ -118,6 +121,10 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         btnDup.addActionListener(this);
         btnDup.putClientProperty(BUTTON_NAME, "btnDup");
 
+        btnEdit = new JButton(App.getCONTEXT().getBundle().getString("edit"));
+        btnEdit.addActionListener(this);
+        btnEdit.putClientProperty(BUTTON_NAME, "btnEdit");
+
         btnConnect = new JButton(App.getCONTEXT().getBundle().getString("connect"));
         btnConnect.addActionListener(this);
         btnConnect.putClientProperty(BUTTON_NAME, "btnConnect");
@@ -139,6 +146,8 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         Box box1 = Box.createHorizontalBox();
         box1.setBorder(getScaledEmptyBorder(10, 10, 10, 10));
         box1.add(Box.createHorizontalGlue());
+        box1.add(Box.createHorizontalStrut(10));
+        box1.add(btnEdit);
         box1.add(Box.createHorizontalStrut(10));
         box1.add(btnConnect);
         box1.add(Box.createHorizontalStrut(10));
@@ -241,6 +250,7 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         txtName.setVisible(false);
         sessionInfoPanel.setVisible(false);
         btnConnect.setVisible(false);
+        setEditMode(false);
 
         // --- Add popup menu for sorting ---
         groupPopupMenu = new JPopupMenu();
@@ -308,6 +318,9 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
                 break;
             case "btnDup":
                 duplicateNode();
+                break;
+            case "btnEdit":
+                toggleEditMode();
                 break;
             case "btnConnect":
                 connectClicked();
@@ -444,7 +457,10 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         treeModel.insertNodeInto(childNode1, parentNode, parentNode.getChildCount());
         tree.scrollPathToVisible(new TreePath(childNode1.getPath()));
         TreePath path2 = new TreePath(childNode1.getPath());
+        pendingEditOnSelect = true;
+        tree.clearSelection();
         tree.setSelectionPath(path2);
+        setEditMode(true);
     }
 
     private void createNewHost(DefaultMutableTreeNode parentNode) {
@@ -459,7 +475,10 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         DefaultMutableTreeNode childNode = getNode(parentNode, rootNode, treeModel);
         tree.scrollPathToVisible(new TreePath(childNode.getPath()));
         TreePath path = new TreePath(childNode.getPath());
+        pendingEditOnSelect = true;
+        tree.clearSelection();
         tree.setSelectionPath(path);
+        setEditMode(true);
     }
 
     private void connectClicked() {
@@ -497,6 +516,10 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
             return;
         }
 
+        boolean shouldEdit = pendingEditOnSelect || editMode;
+        pendingEditOnSelect = false;
+        setEditMode(shouldEdit);
+
         Object nodeInfo = node.getUserObject();
         if (nodeInfo instanceof SessionInfo) {
             sessionInfoPanel.setVisible(true);
@@ -531,7 +554,24 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
                 id = getNewUuid(rootNode);
             }
         }
+        removeInvalidSessionNodes(rootNode);
         SessionStore.save(SessionStore.convertModelFromTree(rootNode), id);
+    }
+
+    private void removeInvalidSessionNodes(DefaultMutableTreeNode node) {
+        for (int i = node.getChildCount() - 1; i >= 0; i--) {
+            DefaultMutableTreeNode child = (DefaultMutableTreeNode) node.getChildAt(i);
+            Object userObj = child.getUserObject();
+            if (userObj instanceof SessionInfo) {
+                SessionInfo session = (SessionInfo) userObj;
+                String host = session.getHost();
+                if (host == null || host.trim().isEmpty()) {
+                    treeModel.removeNodeFromParent(child);
+                }
+            } else {
+                removeInvalidSessionNodes(child);
+            }
+        }
     }
 
     @Override
@@ -554,9 +594,41 @@ public class NewSessionDlg extends JDialog implements ActionListener, TreeSelect
         log.debug("treeStructureChanged");
     }
 
+    private void toggleEditMode() {
+        setEditMode(!editMode);
+    }
+
+    private void setEditMode(boolean enable) {
+        this.editMode = enable;
+        if (btnEdit != null) {
+            btnEdit.setText(App.getCONTEXT().getBundle().getString(enable ? "save" : "edit"));
+        }
+        if (txtName != null) {
+            // Keep field enabled; only toggle editability to keep colors consistent with Host in view mode.
+            txtName.setEnabled(true);
+            txtName.setEditable(enable);
+            txtName.setFocusable(enable);
+            if (enable) {
+                txtName.setBackground(null);
+                txtName.setForeground(null);
+            } else {
+                Color readOnlyBg = App.getCONTEXT().getSkin().getReadOnlyFieldBackground();
+                Color readOnlyFg = App.getCONTEXT().getSkin().getReadOnlyFieldForeground();
+                txtName.setBackground(readOnlyBg);
+                txtName.setForeground(readOnlyFg);
+                txtName.setCaretColor(readOnlyFg);
+            }
+        }
+        if (sessionInfoPanel != null) {
+            sessionInfoPanel.setEditable(enable);
+        }
+    }
+
     private void normalizeButtonSize() {
         int width = Math.max(btnConnect.getPreferredSize().width, btnCancel.getPreferredSize().width);
+        width = Math.max(width, btnEdit.getPreferredSize().width);
         btnConnect.setPreferredSize(scale(new Dimension(width, btnConnect.getPreferredSize().height)));
         btnCancel.setPreferredSize(scale(new Dimension(width, btnCancel.getPreferredSize().height)));
+        btnEdit.setPreferredSize(scale(new Dimension(width, btnEdit.getPreferredSize().height)));
     }
 }

--- a/muon-app/src/main/java/muon/app/ui/laf/AppSkin.java
+++ b/muon-app/src/main/java/muon/app/ui/laf/AppSkin.java
@@ -28,6 +28,8 @@ public abstract class AppSkin {
     public static final String SCROLLBAR = "scrollbar";
     public static final String PAINT_NO_BORDER = "paintNoBorder";
     public static final String TEXT_FIELD_BACKGROUND = "TextField.background";
+    public static final String READ_ONLY_FIELD_BACKGROUND = "readOnlyFieldBackground";
+    public static final String READ_ONLY_FIELD_FOREGROUND = "readOnlyFieldForeground";
     protected UIDefaults defaults;
 
     @Getter
@@ -122,6 +124,16 @@ public abstract class AppSkin {
         return this.defaults.getColor("scrollbar-hot");
     }
 
+    public Color getReadOnlyFieldBackground() {
+        Color c = this.defaults.getColor(READ_ONLY_FIELD_BACKGROUND);
+        return c != null ? c : this.defaults.getColor(TEXT_FIELD_BACKGROUND);
+    }
+
+    public Color getReadOnlyFieldForeground() {
+        Color c = this.defaults.getColor(READ_ONLY_FIELD_FOREGROUND);
+        return c != null ? c : this.defaults.getColor(TEXT);
+    }
+
     public UIDefaults getSplitPaneSkin() {
         UIDefaults uiDefaults = new UIDefaults();
         Painter<?> painter = (Painter<Object>) (g, object, width, height) -> {
@@ -155,6 +167,18 @@ public abstract class AppSkin {
 
     public void createSkinnedButton(UIDefaults btnSkin) {
         RoundedButtonPainter cs = new RoundedButtonPainter(btnSkin);
+        Painter<? extends JComponent> disabledPainter = (Painter<JComponent>) (g, object, width, height) -> {
+            Color disabledBg = defaults.getColor("Button.disabled");
+            if (disabledBg == null) {
+                disabledBg = defaults.getColor("button.normalGradient2");
+            }
+            Color border = defaults.getColor(NIMBUS_BORDER);
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(disabledBg);
+            g.fillRoundRect(1, 1, width - 2, height - 2, 5, 5);
+            g.setColor(border);
+            g.drawRoundRect(1, 1, width - 2, height - 2, 5, 5);
+        };
         btnSkin.put("Button.contentMargins", scaleInsets(8, 15, 8, 15));
         btnSkin.put("Button[Default+Focused+MouseOver].backgroundPainter", cs.getHotPainter());
         btnSkin.put("Button[Default+Focused+Pressed].backgroundPainter", cs.getPressedPainter());
@@ -170,8 +194,8 @@ public abstract class AppSkin {
         btnSkin.put("Button[Pressed].backgroundPainter", cs.getPressedPainter());
         btnSkin.put("Button[Default+Pressed].textForeground", defaults.getColor(CONTROL));
         btnSkin.put("Button.foreground", defaults.getColor(CONTROL));
-        btnSkin.put("Button[Disabled].textForeground", Color.GRAY);
-        btnSkin.put("Button[Disabled].backgroundPainter", cs.getNormalPainter());
+        btnSkin.put("Button[Disabled].textForeground", defaults.getColor("nimbusDisabledText"));
+        btnSkin.put("Button[Disabled].backgroundPainter", disabledPainter);
     }
 
     public void createTextFieldSkin(UIDefaults uiDefaults) {
@@ -214,6 +238,8 @@ public abstract class AppSkin {
 
     public void createSpinnerSkin(UIDefaults uiDefaults) {
         Color c1 = this.defaults.getColor(TEXT_FIELD_BACKGROUND);
+        Color cDisabled = this.defaults.getColor(READ_ONLY_FIELD_BACKGROUND);
+        final Color cDisabledFinal = (cDisabled == null) ? c1 : cDisabled;
         Color c2 = this.defaults.getColor(NIMBUS_BORDER);
 
         Painter<? extends JComponent> painter1 = (Painter<JComponent>) (g, object, width, height) -> {
@@ -240,7 +266,34 @@ public abstract class AppSkin {
             g.drawRoundRect(1 - 20, 1 - 20, width - 2 + 20, height - 2 + 20, 5, 5);
         };
 
-        uiDefaults.put("Spinner:\"Spinner.nextButton\"[Disabled].backgroundPainter", painter2);
+        Painter<? extends JComponent> painter1Disabled = (Painter<JComponent>) (g, object, width, height) -> {
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(cDisabledFinal);
+            g.fillRoundRect(1, 1, width - 2 + 20, height - 2, 5, 5);
+            g.setColor(c2);
+            g.drawRoundRect(1, 1, width - 2 + 20, height - 2, 5, 5);
+        };
+
+        Painter<? extends JComponent> painter2Disabled = (Painter<JComponent>) (g, object, width, height) -> {
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(cDisabledFinal);
+            g.fillRoundRect(1 - 20, 1, width - 2 + 20, height - 2 + 20, 5, 5);
+            g.setColor(c2);
+            g.drawRoundRect(1 - 20, 1, width - 2 + 20, height - 2 + 20, 5, 5);
+        };
+
+        Painter<? extends JComponent> painter3Disabled = (Painter<JComponent>) (g, object, width, height) -> {
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(cDisabledFinal);
+            g.fillRoundRect(1 - 20, 1 - 20, width - 2 + 20, height - 2 + 20, 5, 5);
+            g.setColor(c2);
+            g.drawRoundRect(1 - 20, 1 - 20, width - 2 + 20, height - 2 + 20, 5, 5);
+        };
+
+        uiDefaults.put("Spinner:\"Spinner.nextButton\"[Disabled].backgroundPainter", painter2Disabled);
+        uiDefaults.put("Spinner:\"Spinner.nextButton\"[Disabled+Focused].backgroundPainter", painter2Disabled);
+        uiDefaults.put("Spinner:\"Spinner.nextButton\"[Focused+Disabled].backgroundPainter", painter2Disabled);
+        uiDefaults.put("Spinner:\"Spinner.nextButton\"[Disabled+Selected].backgroundPainter", painter2Disabled);
         uiDefaults.put("Spinner:\"Spinner.nextButton\"[Enabled].backgroundPainter", painter2);
         uiDefaults.put("Spinner:\"Spinner.nextButton\"[Focused+MouseOver].backgroundPainter", painter2);
         uiDefaults.put("Spinner:\"Spinner.nextButton\"[Focused+Pressed].backgroundPainter", painter2);
@@ -248,7 +301,10 @@ public abstract class AppSkin {
         uiDefaults.put("Spinner:\"Spinner.nextButton\"[MouseOver].backgroundPainter", painter2);
         uiDefaults.put("Spinner:\"Spinner.nextButton\"[Pressed].backgroundPainter", painter2);
 
-        uiDefaults.put("Spinner:\"Spinner.previousButton\"[Disabled].backgroundPainter", painter3);
+        uiDefaults.put("Spinner:\"Spinner.previousButton\"[Disabled].backgroundPainter", painter3Disabled);
+        uiDefaults.put("Spinner:\"Spinner.previousButton\"[Disabled+Focused].backgroundPainter", painter3Disabled);
+        uiDefaults.put("Spinner:\"Spinner.previousButton\"[Focused+Disabled].backgroundPainter", painter3Disabled);
+        uiDefaults.put("Spinner:\"Spinner.previousButton\"[Disabled+Selected].backgroundPainter", painter3Disabled);
         uiDefaults.put("Spinner:\"Spinner.previousButton\"[Enabled].backgroundPainter", painter3);
         uiDefaults.put("Spinner:\"Spinner.previousButton\"[Focused+MouseOver].backgroundPainter", painter3);
         uiDefaults.put("Spinner:\"Spinner.previousButton\"[Focused+Pressed].backgroundPainter", painter3);
@@ -257,14 +313,22 @@ public abstract class AppSkin {
         uiDefaults.put("Spinner:\"Spinner.previousButton\"[Pressed].backgroundPainter", painter3);
 
         uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Enabled].backgroundPainter", painter1);
+        uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Disabled].backgroundPainter", painter1Disabled);
+        uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Disabled+Focused].backgroundPainter", painter1Disabled);
+        uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Focused+Disabled].backgroundPainter", painter1Disabled);
+        uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Disabled+Selected].backgroundPainter", painter1Disabled);
+        uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Focused+Selected+Disabled].backgroundPainter", painter1Disabled);
         uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Focused].backgroundPainter", painter1);
         uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\"[Focused+Selected].backgroundPainter", painter1);
+        uiDefaults.put("Spinner[Disabled].backgroundPainter", painter1Disabled);
         uiDefaults.put("Spinner:Panel:\"Spinner.formattedTextField\".contentMargins", scaleInsets(7, 7, 7, 7));
     }
 
     public void createComboBoxSkin(UIDefaults uiDefaults) {
         Color c1 = this.defaults.getColor(NIMBUS_BORDER);
         Color c2 = this.defaults.getColor(TEXT_FIELD_BACKGROUND);
+        Color cDisabled = this.defaults.getColor(READ_ONLY_FIELD_BACKGROUND);
+        final Color cDisabledFinal = (cDisabled == null) ? c2 : cDisabled;
         Painter<? extends JComponent> painter1 = (Painter<JComponent>) (g, object, width, height) -> {
             if (object.getClientProperty(PAINT_NO_BORDER) != null) {
                 return;
@@ -319,9 +383,26 @@ public abstract class AppSkin {
             g.setColor(c1);
             g.drawRoundRect(1, 1, width - 2, height - 2, 5, 5);
         };
+
+        Painter<? extends JComponent> painterDisabled = (Painter<JComponent>) (g, object, width, height) -> {
+            if (object.getClientProperty(PAINT_NO_BORDER) != null) {
+                return;
+            }
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setColor(cDisabledFinal);
+            g.fillRoundRect(1, 1, width - 2, height - 2, 5, 5);
+            g.setColor(c1);
+            g.drawRoundRect(1, 1, width - 2, height - 2, 5, 5);
+        };
         uiDefaults.put("ComboBox:\"ComboBox.textField\"[Enabled].backgroundPainter", painter3);
+        uiDefaults.put("ComboBox:\"ComboBox.textField\"[Disabled].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox:\"ComboBox.textField\"[Disabled+Focused].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox:\"ComboBox.textField\"[Focused+Disabled].backgroundPainter", painterDisabled);
         uiDefaults.put("ComboBox:\"ComboBox.textField\"[Selected].backgroundPainter", painter3);
         uiDefaults.put("ComboBox[Enabled].backgroundPainter", painter4);
+        uiDefaults.put("ComboBox[Disabled].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox[Disabled+Focused].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox[Focused+Disabled].backgroundPainter", painterDisabled);
         uiDefaults.put("ComboBox[Focused+MouseOver].backgroundPainter", painter5);
         uiDefaults.put("ComboBox[Focused+Pressed].backgroundPainter", painter5);
         uiDefaults.put("ComboBox[Focused].backgroundPainter", painter4);
@@ -329,12 +410,16 @@ public abstract class AppSkin {
         uiDefaults.put("ComboBox[Pressed].backgroundPainter", painter1);
         uiDefaults.put("ComboBox[Editable+Focused].backgroundPainter", painter4);
         uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+Enabled].backgroundPainter", painter3);
+        uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Disabled].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+Disabled].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Disabled+Focused].backgroundPainter", painterDisabled);
+        uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+Disabled+Focused].backgroundPainter", painterDisabled);
         uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+MouseOver].backgroundPainter", painter2);
         uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+Pressed].backgroundPainter", painter2);
         uiDefaults.put("ComboBox:\"ComboBox.arrowButton\"[Editable+Selected].backgroundPainter", painter3);
         uiDefaults.put("ComboBox.contentMargins", scaleInsets(3, 5, 3, 5));
         uiDefaults.put("ComboBox:\"ComboBox.listRenderer\".contentMargins", scaleInsets(3, 5, 3, 5));
-        uiDefaults.put("ComboBox.rendererUseListColors", Boolean.TRUE);
+        uiDefaults.put("ComboBox.rendererUseListColors", Boolean.FALSE);
     }
 
     public void createTreeSkin(UIDefaults uiDefaults) {

--- a/muon-app/src/main/java/muon/app/ui/laf/AppSkinDark.java
+++ b/muon-app/src/main/java/muon/app/ui/laf/AppSkinDark.java
@@ -17,6 +17,8 @@ public class AppSkinDark extends AppSkin {
         Color selectedTextColor = new Color(230, 230, 230);
         Color infoTextColor = new Color(180, 180, 180);
         Color borderColor = new Color(24, 26, 31);
+        Color readOnlyFieldBackground = new Color(68, 72, 84);
+        Color readOnlyFieldForeground = new Color(225, 225, 225);
         Color treeTextColor = new Color(75 + 20, 83 + 20, 98 + 20);
         Color scrollbarColor = new Color(75, 83, 98);
         Color scrollbarRolloverColor = new Color(75 + 20, 83 + 20, 98 + 20);
@@ -29,7 +31,8 @@ public class AppSkinDark extends AppSkin {
         Color buttonGradient5 = new Color(57 - 20, 62 - 20, 74 - 20);
         Color buttonGradient6 = new Color(57 - 10, 62 - 10, 74 - 10);
 
-        Color disabledText = new Color(130, 130, 130);
+        Color disabledText = readOnlyFieldForeground;
+        Color disabledFieldBackground = readOnlyFieldBackground;
 
         this.defaults.put("nimbusBase", controlColor);
         this.defaults.put("nimbusSelection", selectionColor);
@@ -46,6 +49,8 @@ public class AppSkinDark extends AppSkin {
         this.defaults.put("nimbusBorder", borderColor);
         this.defaults.put("Table.alternateRowColor", controlColor);
         this.defaults.put("nimbusLightBackground", textFieldColor);
+        this.defaults.put(READ_ONLY_FIELD_BACKGROUND, readOnlyFieldBackground);
+        this.defaults.put(READ_ONLY_FIELD_FOREGROUND, readOnlyFieldForeground);
 
         this.defaults.put("tabSelectionBackground", scrollbarColor);
         this.defaults.put("Table.background", buttonGradient6);
@@ -81,12 +86,35 @@ public class AppSkinDark extends AppSkin {
         this.defaults.put("TextField.background", textFieldColor);
         this.defaults.put("FormattedTextField.background", textFieldColor);
         this.defaults.put("PasswordField.background", textFieldColor);
+        this.defaults.put("TextArea.background", textFieldColor);
+        this.defaults.put("EditorPane.background", textFieldColor);
 
         this.defaults.put("nimbusDisabledText", disabledText);
         this.defaults.put("Label.disabledForeground", disabledText);
 
         this.defaults.put("CheckBox[Disabled].textForeground", disabledText);
         this.defaults.put("CheckBox.disabledText", disabledText);
+        this.defaults.put("RadioButton[Disabled].textForeground", disabledText);
+        this.defaults.put("RadioButton.disabledText", disabledText);
+        this.defaults.put("Button[Disabled].textForeground", disabledText);
+        this.defaults.put("Button.disabledText", disabledText);
+        this.defaults.put("Button.disabled", disabledFieldBackground);
+        this.defaults.put("ComboBox.disabledForeground", disabledText);
+        this.defaults.put("ComboBox.disabledBackground", disabledFieldBackground);
+        this.defaults.put("TextField.disabledText", disabledText);
+        this.defaults.put("TextField.inactiveForeground", disabledText);
+        this.defaults.put("TextField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("TextField.inactiveBackground", disabledFieldBackground);
+        this.defaults.put("FormattedTextField.disabledText", disabledText);
+        this.defaults.put("FormattedTextField.inactiveForeground", disabledText);
+        this.defaults.put("FormattedTextField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("FormattedTextField.inactiveBackground", disabledFieldBackground);
+        this.defaults.put("PasswordField.disabledText", disabledText);
+        this.defaults.put("PasswordField.inactiveForeground", disabledText);
+        this.defaults.put("PasswordField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("PasswordField.inactiveBackground", disabledFieldBackground);
+        this.defaults.put("TextArea.disabledText", disabledText);
+        this.defaults.put("TextArea.disabledBackground", disabledFieldBackground);
 
         createSkinnedButton(this.defaults);
         createTextFieldSkin(this.defaults);

--- a/muon-app/src/main/java/muon/app/ui/laf/AppSkinLight.java
+++ b/muon-app/src/main/java/muon/app/ui/laf/AppSkinLight.java
@@ -21,6 +21,8 @@ public class AppSkinLight extends AppSkin {
         Color selectedTextColor = new Color(250, 250, 250);
         Color infoTextColor = new Color(80, 80, 80);
         Color borderColor = new Color(230, 230, 230);
+        Color readOnlyFieldBackground = new Color(236, 238, 242);
+        Color readOnlyFieldForeground = new Color(45, 45, 45);
         Color treeTextColor = new Color(150, 150, 150);
         Color scrollbarColor = new Color(200, 200, 200);
         Color scrollbarRolloverColor = new Color(230, 230, 230);
@@ -36,7 +38,8 @@ public class AppSkinLight extends AppSkin {
 
         Color buttonGradient7 = new Color(248, 248, 249);
 
-        Color disabledText = new Color(140, 140, 140);
+        Color disabledText = readOnlyFieldForeground;
+        Color disabledFieldBackground = readOnlyFieldBackground;
 
         this.defaults.put("nimbusBase", controlColor);
         this.defaults.put("nimbusSelection", selectionColor);
@@ -52,6 +55,8 @@ public class AppSkinLight extends AppSkin {
         this.defaults.put("control", controlColor);
         this.defaults.put("nimbusBorder", borderColor);
         this.defaults.put("nimbusLightBackground", controlColor);
+        this.defaults.put(READ_ONLY_FIELD_BACKGROUND, readOnlyFieldBackground);
+        this.defaults.put(READ_ONLY_FIELD_FOREGROUND, readOnlyFieldForeground);
 
         this.defaults.put("Table.alternateRowColor", controlColor);
 
@@ -93,6 +98,23 @@ public class AppSkinLight extends AppSkin {
         this.defaults.put("Label.disabledForeground", disabledText);
         this.defaults.put("CheckBox[Disabled].textForeground", disabledText);
         this.defaults.put("CheckBox.disabledText", disabledText);
+        this.defaults.put("RadioButton[Disabled].textForeground", disabledText);
+        this.defaults.put("RadioButton.disabledText", disabledText);
+        this.defaults.put("Button[Disabled].textForeground", disabledText);
+        this.defaults.put("ComboBox.disabledForeground", disabledText);
+        this.defaults.put("ComboBox.disabledBackground", disabledFieldBackground);
+        this.defaults.put("TextField.disabledText", disabledText);
+        this.defaults.put("TextField.inactiveForeground", disabledText);
+        this.defaults.put("TextField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("TextField.inactiveBackground", disabledFieldBackground);
+        this.defaults.put("FormattedTextField.disabledText", disabledText);
+        this.defaults.put("FormattedTextField.inactiveForeground", disabledText);
+        this.defaults.put("FormattedTextField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("FormattedTextField.inactiveBackground", disabledFieldBackground);
+        this.defaults.put("PasswordField.disabledText", disabledText);
+        this.defaults.put("PasswordField.inactiveForeground", disabledText);
+        this.defaults.put("PasswordField.disabledBackground", disabledFieldBackground);
+        this.defaults.put("PasswordField.inactiveBackground", disabledFieldBackground);
 
         createSkinnedButton(this.defaults);
         createTextFieldSkin(this.defaults);


### PR DESCRIPTION
add site and folder management safer and easier to use by preventing accidental edits by making read-only and edit mode.

**Added explicit Edit/Save workflow**:
- Default is view mode (read-only).
- Edit mode is sticky across selection changes.
- New site and new folder open directly in edit mode.


<img width="500" height="350" alt="Screenshot 2026-03-05 at 10 31 12 PM" src="https://github.com/user-attachments/assets/f69546c8-52b9-4dcc-b4d6-695c18cb2423" />
<img width="500" height="350" alt="Screenshot 2026-03-05 at 10 31 17 PM" src="https://github.com/user-attachments/assets/c19d9101-a27a-4534-b570-3aacd5e62375" />
